### PR TITLE
Fixing issues with PNG thumbnails

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -12,7 +12,7 @@ coreapi-cli==1.0.6
 gunicorn==19.6.0
 requests==2.11.1
 six==1.10.0
-Pillow==2.7.0
+Pillow==5.1.0
 mysqlclient==1.3.12
 mock==2.0.0
 pytz==2016.10

--- a/v1/recipe/models.py
+++ b/v1/recipe/models.py
@@ -41,7 +41,6 @@ class Recipe(models.Model):
     photo = models.ImageField(_('photo'), blank=True, upload_to="upload/recipe_photos")
     photo_thumbnail = ImageSpecField(source='photo',
                                      processors=[ResizeToFill(300, 200)],
-                                     format='JPEG',
                                      options={'quality': 70})
     cuisine = models.ForeignKey(Cuisine, on_delete=models.CASCADE)
     course = models.ForeignKey(Course, on_delete=models.CASCADE)

--- a/v1/recipe/models.py
+++ b/v1/recipe/models.py
@@ -41,6 +41,7 @@ class Recipe(models.Model):
     photo = models.ImageField(_('photo'), blank=True, upload_to="upload/recipe_photos")
     photo_thumbnail = ImageSpecField(source='photo',
                                      processors=[ResizeToFill(300, 200)],
+                                     format='JPEG',
                                      options={'quality': 70})
     cuisine = models.ForeignKey(Cuisine, on_delete=models.CASCADE)
     course = models.ForeignKey(Course, on_delete=models.CASCADE)


### PR DESCRIPTION
The version of pillow was so old the library that was trying to convert the images was failing silently.

To Test:
- Try adding a PNG to a recipe and make sure the thumbnail is generated.