### PR TITLE
Add env flag to be able to change database engine

### DIFF
--- a/base/settings.py
+++ b/base/settings.py
@@ -24,20 +24,19 @@ SITE_ID = 1
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': os.environ.get('DATABASE_ENGINE', 'django.db.backends.mysql'),
         'NAME': os.environ.get('MYSQL_DATABASE', 'openeats'),
         'USER': os.environ.get('MYSQL_USER', 'root'),
         'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD', ''),
         'HOST': os.environ.get('MYSQL_HOST', 'db'),
         'PORT': os.environ.get('MYSQL_PORT', '3306'),
-        'OPTIONS': {
-            'charset': 'utf8mb4'
-        },
         'TEST': {
             'NAME': os.environ.get('MYSQL_TEST_DATABASE', 'test_openeats')
         }
     }
 }
+if 'django.db.backends.mysql' in DATABASES['default']['ENGINE']:
+    DATABASES['default']['OPTIONS']['charset'] = 'utf8mb4'
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts

--- a/base/settings.py
+++ b/base/settings.py
@@ -36,6 +36,7 @@ DATABASES = {
     }
 }
 if 'django.db.backends.mysql' in DATABASES['default']['ENGINE']:
+    DATABASES['default'].setdefault('OPTIONS', {})
     DATABASES['default']['OPTIONS']['charset'] = 'utf8mb4'
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False


### PR DESCRIPTION
The platform works great with postgres, just needed to make a tiny change to allow it.

* You can't set the charset to utf8mb4 with postgres, so only set it when its mysql (default)
* Allow database engine to be changed (MYSQL_ENGINE would be sticking to convention, but felt wrong).

I can add DATABASE_USER which defaults to MYSQL_USER which defaults to 'root' if you want make it more generic

