### PR TITLE
Add order field to Grocery lists

### DIFF
--- a/v1/list/migrations/0009_ordered_grocery_item.py
+++ b/v1/list/migrations/0009_ordered_grocery_item.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('list', '0008_auto_20181120_0041'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='groceryitem',
+            name='order',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterModelOptions(
+            name='groceryitem',
+            options={'ordering': ['list_id', 'order', 'pk']},
+        ),
+    ]

--- a/v1/list/models.py
+++ b/v1/list/models.py
@@ -41,13 +41,15 @@ class GroceryItem(models.Model):
     title = The name of the GroceryItem.
     completed = Whether or not the GroceryItem has been purchased or
                 added to the users shopping cart in the supermarket.
+    order = The order of the item in the GroceryList.
     """
     list = models.ForeignKey(GroceryList, on_delete=models.CASCADE, related_name='items')
     title = models.CharField(_("title"), max_length=550)
     completed = models.BooleanField(_("completed"), default=False)
+    order = models.IntegerField(_("order"), default=0)
 
     class Meta:
-        ordering = ['pk']
+        ordering = ['list_id', 'order', 'pk']
 
     def __str__(self):
         return '%s' % self.title

--- a/v1/list/serializers.py
+++ b/v1/list/serializers.py
@@ -10,7 +10,7 @@ class GroceryItemSerializer(serializers.ModelSerializer):
     """Generic Serializer for grocery items"""
     class Meta:
         model = GroceryItem
-        fields = ('id', 'list', 'title', 'completed')
+        fields = ('id', 'list', 'title', 'completed', 'order')
 
 
 class GroceryListSerializer(serializers.ModelSerializer):
@@ -44,4 +44,4 @@ class BulkGroceryItemSerializer(BulkSerializerMixin, serializers.ModelSerializer
     class Meta:
         model = GroceryItem
         list_serializer_class = BulkListSerializer
-        fields = ('id', 'list', 'title', 'completed')
+        fields = ('id', 'list', 'title', 'completed', 'order')


### PR DESCRIPTION
This field allows for reordering of Grocery lists. The UI for doing so
is obviously in the web project.

Web PR: open-eats/openeats-web#44