### PR TITLE
Fixing exception if grocerylist is shared

### DIFF
--- a/v1/list/permissions.py
+++ b/v1/list/permissions.py
@@ -32,4 +32,4 @@ class IsItemOwner(permissions.BasePermission):
 
         # Write/Read permissions are only allowed to the owner of the list.
         return obj.list.author == request.user or \
-               obj.list.groceryshared.shared_to == request.user
+               obj.list.groceryshared_set.filter(shared_by=obj.list.author.pk, shared_to=request.user.pk).exists()


### PR DESCRIPTION
Hey guys,

love your work :heart:, been using it for the last 6 months, it made organising my diet a lot easier.

I know it was a small hack, but I started to share one of the grocery lists, sharing works surprisingly well, until the other person wants to update.

This merge requests fixes the permission checking, since it seems that `obj.list.groceryshared` is not valid. I am not a pro with django, so I am not sure if I need to add some kind of migration file to complete this requests. Any help would be welcome.

I hope I can improve the software with this tiny commit and help stabilizing it. Keep the good work up.

Thanks and cheers 